### PR TITLE
CC-26448 Added info messages showing

### DIFF
--- a/src/Spryker/Zed/ZedUi/Presentation/Partials/FlashMessages/flash-messages.twig
+++ b/src/Spryker/Zed/ZedUi/Presentation/Partials/FlashMessages/flash-messages.twig
@@ -10,3 +10,9 @@
         <span title>{{ message | trans }}</span>
     </web-spy-notification>
 {% endfor %}
+
+{% for message in app.session.flashbag.get('flash.messages.info') %}
+    <web-spy-notification type="info" closeable="true">
+        <span title>{{ message | trans }}</span>
+    </web-spy-notification>
+{% endfor %}


### PR DESCRIPTION
Branch: backport/1.8.0
Ticket: https://spryker.atlassian.net/browse/CC-26448
Version: 1.8.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ZedUi  | minor                 |                       |

-----------------------------------------

#### Module ZedUi

##### Change log

Improvements

- Adjusted `flash-messages.twig` so it supports info notifications showing now.
